### PR TITLE
Improvements with two added configuration options `ignore_nofollow`,`ignored_hrefs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Sitemap crawler/generator. For given URL it will return sitemap XML file.
 
 ## Install
 ```sh
-composer require ivebe/sitemap-crawler
+composer require dkudev/sitemap-crawler
 ```
 
 ## Example

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
     "license": "MIT",
     "authors": [
         {
+            "name": "Danijel Petrovic",
+            "email": "dan@ivebe.com"
+        },
+        {
             "name": "Dimitar Kudev",
             "email": "dimitar.kudev@gmail.com"
         }

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "ivebe/sitemap-crawler",
+    "name": "dkudev/sitemap-crawler",
     "description": "Sitemap crawler/generator. For given URL it will return sitemap XML file.",
     "type": "library",
     "license": "MIT",
     "authors": [
         {
-            "name": "Danijel Petrovic",
-            "email": "dan@ivebe.com"
+            "name": "Dimitar Kudev",
+            "email": "dimitar.kudev@gmail.com"
         }
     ],
     "require": {

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -112,7 +112,7 @@ class Crawler implements ICrawler
     private function shouldExclude($linkHaystack)
     {
         foreach ($this->getIgnoredHrefs() as $ignoredHref) {
-            if (strpos($linkHaystack, $ignoredHref)) {
+            if (strpos($linkHaystack, $ignoredHref) !== false) {
                 return true;
             }
         }


### PR DESCRIPTION
1. Add configuration option `ignore_nofollow` to ignore all a tags with data attribute data-nofollow and rel='nofollow'
2. Add configuration option `ignored_hrefs` to ignore specific urls being stored in the links array.